### PR TITLE
chore: add logs/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+logs/
 
 website/vendor
 


### PR DESCRIPTION
## Summary

Adds the `logs/` directory to `.gitignore` to prevent Claude Code conversation logs from
being tracked in version control.

## Justification

The `logs/` directory is used by Claude Code to store conversation history and session data
  during AI-assisted development. This directory should not be tracked in version control
because:

1. **Contains local development artifacts**: Claude Code conversation logs are specific to
individual developer sessions and have no value to other contributors
2. **Privacy and security**: Conversation logs may contain sensitive information, API
interactions, or debugging details that shouldn't be shared in the repository
3. **Noise in git status**: The untracked `logs/` directory creates unnecessary clutter in
`git status` output during Claude Code sessions
4. **Prevent accidental commits**: Reduces the risk of inadvertently committing large
conversation history files that accumulate during extended AI-assisted development sessions
5. **Consistency**: Aligns with the existing pattern of ignoring development-time artifacts
  like `.terraform/`, `.env`, and `*.log` files

While individual `*.log` files are already ignored, the `logs/` directory itself needs
explicit exclusion to prevent the directory structure from being tracked.

## Changes

- Added `logs/` entry to `.gitignore` at line 28

## Testing

- Verified that the `logs/` directory no longer appears as untracked in `git status` after
this change
- Confirmed no impact to existing ignored patterns