### PR TITLE
fix: forward host and protocol in provider_devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix `render_device_configs` function corrupting shared configuration when nested maps (e.g. `ip`, `ntp`) appear in both a source config (interface group, device group, or global) and a higher-precedence config — causing later devices or interfaces to inherit values from earlier ones
+- Fix `render_device_configs` dropping `host` and `protocol` from `provider_devices` — only `url` was forwarded, so devices declared with `host` (the non-deprecated connection field) had no connection target in the provider devices list
 
 ## 2.0.1
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -10,6 +10,7 @@ description: |-
 ## Unreleased
 
 - Fix `render_device_configs` function corrupting shared configuration when nested maps (e.g. `ip`, `ntp`) appear in both a source config (interface group, device group, or global) and a higher-precedence config — causing later devices or interfaces to inherit values from earlier ones
+- Fix `render_device_configs` dropping `host` and `protocol` from `provider_devices` — only `url` was forwarded, so devices declared with `host` (the non-deprecated connection field) had no connection target in the provider devices list
 
 ## 2.0.1
 

--- a/internal/provider/function_render_device_configs.go
+++ b/internal/provider/function_render_device_configs.go
@@ -968,7 +968,8 @@ func stripNulls(v any) any {
 	}
 }
 
-// buildProviderDevices extracts name/url/managed from all devices for provider configuration.
+// buildProviderDevices extracts name/managed and connection fields (url/host/protocol)
+// from all devices for provider configuration.
 func buildProviderDevices(model map[string]any, arch string, defaultManaged bool) []any {
 	archConfig := getMapVal(model, arch)
 	devices := getSliceVal(archConfig, "devices")
@@ -982,8 +983,11 @@ func buildProviderDevices(model map[string]any, arch string, defaultManaged bool
 			"name":    getStringVal(dm, "name", ""),
 			"managed": getBoolVal(dm, "managed", defaultManaged),
 		}
-		if url, ok := dm["url"]; ok && url != nil {
-			pd["url"] = url
+		// Copy optional connection fields (omit if not present)
+		for _, field := range []string{"url", "host", "protocol"} {
+			if v, ok := dm[field]; ok && v != nil {
+				pd[field] = v
+			}
 		}
 		result = append(result, pd)
 	}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -10,6 +10,7 @@ description: |-
 ## Unreleased
 
 - Fix `render_device_configs` function corrupting shared configuration when nested maps (e.g. `ip`, `ntp`) appear in both a source config (interface group, device group, or global) and a higher-precedence config — causing later devices or interfaces to inherit values from earlier ones
+- Fix `render_device_configs` dropping `host` and `protocol` from `provider_devices` — only `url` was forwarded, so devices declared with `host` (the non-deprecated connection field) had no connection target in the provider devices list
 
 ## 2.0.1
 


### PR DESCRIPTION
## What

`buildProviderDevices` emits only `name`/`managed`/`url` per device, dropping `host`. The main device builder already copies `url`/`host`/`protocol` into the `resolved` tree (same file, ~line 569), but `provider_devices` never gets `host`.

## Why it matters

`host` is the non-deprecated connection field (the IOS-XE provider deprecates `url` in favor of `host`). A device declared with `host:` (no `url:`) renders into `resolved.…devices[].host` but lands in `provider_devices` as `{name, managed}` only. Consumers that wire `provider_devices` straight into the provider (e.g. `terraform-iosxe-nac-iosxe`, after netascode/terraform-iosxe-nac-iosxe#315 switched to `render_device_configs`) then configure the provider with an empty host → `Host or URL cannot be an empty string` on every apply.

## Fix

Forward `host` and `protocol` alongside `url` in `buildProviderDevices`, mirroring the existing optional-field copy used for the device output.

Companion module fix (the other half needed to unblock that consumer): netascode/terraform-iosxe-nac-iosxe (defaults change). Verified together against a live IOS-XE device — apply/destroy clean.
