### PR TITLE
feat(render): add interface_group_policy for merge/replace control

### DIFF
--- a/internal/provider/function_render_device_configs.go
+++ b/internal/provider/function_render_device_configs.go
@@ -546,6 +546,9 @@ func renderSingleDevice(rctx *renderContext, device map[string]any) (map[string]
 		applyDefaults(merged, rctx.defaultConfig)
 	}
 
+	// 4e3. Apply interface_group_policy (replace semantics)
+	applyInterfaceGroupPolicy(merged, device)
+
 	// 4f. Interface groups
 	igConfigs, err := resolveInterfaceGroupConfigs(rctx, ctyVars)
 	if err != nil {
@@ -717,6 +720,71 @@ func resolveInterfaceGroupConfigs(rctx *renderContext, vars map[string]cty.Value
 		}
 	}
 	return igConfigs, nil
+}
+
+// applyInterfaceGroupPolicy enforces merge/replace semantics for interface_groups
+// between device_group and device layers. Must be called after the merge cascade
+// but before applyInterfaceGroups.
+func applyInterfaceGroupPolicy(merged map[string]any, device map[string]any) {
+	devicePolicy := getStringVal(device, "interface_group_policy", "merge")
+	deviceConfig := getMapVal(device, "configuration")
+	deviceInterfaces := getMapVal(deviceConfig, "interfaces")
+
+	if devicePolicy == "merge" && len(deviceInterfaces) == 0 {
+		return
+	}
+
+	mergedInterfaces := getMapVal(merged, "interfaces")
+	if len(mergedInterfaces) == 0 {
+		return
+	}
+
+	for typeName, typeVal := range mergedInterfaces {
+		items, ok := typeVal.([]any)
+		if !ok {
+			continue
+		}
+		deviceTypeItems := getSliceVal(deviceInterfaces, typeName)
+
+		for i, itemRaw := range items {
+			itemMap := toMapStringAny(itemRaw)
+			if itemMap == nil {
+				continue
+			}
+
+			effectivePolicy := getStringVal(itemMap, "interface_group_policy", devicePolicy)
+			if effectivePolicy != "replace" {
+				continue
+			}
+
+			if deviceGroups, found := deviceOnlyInterfaceGroups(itemMap, deviceTypeItems); found {
+				if deviceGroups == nil {
+					delete(itemMap, "interface_groups")
+				} else {
+					itemMap["interface_groups"] = deviceGroups
+				}
+				items[i] = itemMap
+			}
+		}
+		mergedInterfaces[typeName] = items
+	}
+	merged["interfaces"] = mergedInterfaces
+}
+
+// deviceOnlyInterfaceGroups returns the interface_groups list from the device-only
+// config item that matches the given merged item (by primitive field equality).
+// Returns (groups, true) if a matching device-only item exists, (nil, false) otherwise.
+func deviceOnlyInterfaceGroups(mergedItem map[string]any, deviceItems []any) ([]any, bool) {
+	for _, diRaw := range deviceItems {
+		di := toMapStringAny(diRaw)
+		if di == nil {
+			continue
+		}
+		if itemsWouldMerge(mergedItem, di) {
+			return getSliceVal(di, "interface_groups"), true
+		}
+	}
+	return nil, false
 }
 
 func applyInterfaceGroups(config map[string]any, igConfigs map[string]map[string]any) {

--- a/internal/provider/function_render_device_configs.go
+++ b/internal/provider/function_render_device_configs.go
@@ -753,18 +753,46 @@ func applyInterfaceGroupPolicy(merged map[string]any, device map[string]any) {
 			}
 
 			effectivePolicy := getStringVal(itemMap, "interface_group_policy", devicePolicy)
-			if effectivePolicy != "replace" {
-				continue
+			if effectivePolicy == "replace" {
+				if deviceGroups, found := deviceOnlyInterfaceGroups(itemMap, deviceTypeItems); found {
+					if deviceGroups == nil {
+						delete(itemMap, "interface_groups")
+					} else {
+						itemMap["interface_groups"] = deviceGroups
+					}
+				}
 			}
 
-			if deviceGroups, found := deviceOnlyInterfaceGroups(itemMap, deviceTypeItems); found {
-				if deviceGroups == nil {
-					delete(itemMap, "interface_groups")
-				} else {
-					itemMap["interface_groups"] = deviceGroups
+			// Recurse into subinterfaces with device-level policy
+			if subsRaw, ok := itemMap["subinterfaces"]; ok {
+				if subs, ok := subsRaw.([]any); ok {
+					var deviceSubs []any
+					if di := findMatchingDeviceItem(itemMap, deviceTypeItems); di != nil {
+						deviceSubs = getSliceVal(di, "subinterfaces")
+					}
+					for j, subRaw := range subs {
+						subMap := toMapStringAny(subRaw)
+						if subMap == nil {
+							continue
+						}
+						subPolicy := getStringVal(subMap, "interface_group_policy", devicePolicy)
+						if subPolicy != "replace" {
+							continue
+						}
+						if deviceGroups, found := deviceOnlyInterfaceGroups(subMap, deviceSubs); found {
+							if deviceGroups == nil {
+								delete(subMap, "interface_groups")
+							} else {
+								subMap["interface_groups"] = deviceGroups
+							}
+							subs[j] = subMap
+						}
+					}
+					itemMap["subinterfaces"] = subs
 				}
-				items[i] = itemMap
 			}
+
+			items[i] = itemMap
 		}
 		mergedInterfaces[typeName] = items
 	}
@@ -785,6 +813,21 @@ func deviceOnlyInterfaceGroups(mergedItem map[string]any, deviceItems []any) ([]
 		}
 	}
 	return nil, false
+}
+
+// findMatchingDeviceItem returns the device-only item that matches the given
+// merged item by primitive field equality, or nil if no match is found.
+func findMatchingDeviceItem(mergedItem map[string]any, deviceItems []any) map[string]any {
+	for _, diRaw := range deviceItems {
+		di := toMapStringAny(diRaw)
+		if di == nil {
+			continue
+		}
+		if itemsWouldMerge(mergedItem, di) {
+			return di
+		}
+	}
+	return nil
 }
 
 func applyInterfaceGroups(config map[string]any, igConfigs map[string]map[string]any) {

--- a/internal/provider/function_render_device_configs_test.go
+++ b/internal/provider/function_render_device_configs_test.go
@@ -1304,3 +1304,485 @@ EOT
 	}
 	`
 }
+
+func TestRenderDeviceConfigsFunction_InterfaceGroupPolicyReplace(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRenderDeviceConfigs_interfaceGroupPolicyReplace(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("eth1_mtu", "9216"),
+					resource.TestCheckOutput("eth1_description", "TRUNK_VIA_GROUP"),
+					resource.TestCheckOutput("eth2_mtu", "1500"),
+					resource.TestCheckOutput("eth2_description", "ACCESS_VIA_GROUP"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRenderDeviceConfigs_interfaceGroupPolicyReplace() string {
+	return `
+	locals {
+		model = {
+			iosxe = {
+				interface_groups = [
+					{
+						name = "access"
+						configuration = {
+							mtu = 1500
+							description = "ACCESS_VIA_GROUP"
+						}
+					},
+					{
+						name = "trunk"
+						configuration = {
+							mtu = 9216
+							description = "TRUNK_VIA_GROUP"
+						}
+					}
+				]
+				device_groups = [
+					{
+						name    = "switches"
+						devices = ["switch1"]
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["access"]
+									},
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/2"
+										interface_groups = ["access"]
+									}
+								]
+							}
+						}
+					}
+				]
+				devices = [
+					{
+						name = "switch1"
+						interface_group_policy = "replace"
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["trunk"]
+									}
+								]
+							}
+						}
+					}
+				]
+			}
+		}
+
+		result = provider::utils::render_device_configs([], local.model, "", {}, [], [])
+		device = local.result.raw.iosxe.devices[0]
+		eth1   = [for e in local.device.configuration.interfaces.ethernets : e if e.type == "GigabitEthernet" && e.id == "1/0/1"][0]
+		eth2   = [for e in local.device.configuration.interfaces.ethernets : e if e.type == "GigabitEthernet" && e.id == "1/0/2"][0]
+	}
+
+	output "eth1_mtu" {
+		value = tostring(local.eth1.mtu)
+	}
+	output "eth1_description" {
+		value = local.eth1.description
+	}
+	output "eth2_mtu" {
+		value = tostring(local.eth2.mtu)
+	}
+	output "eth2_description" {
+		value = local.eth2.description
+	}
+	`
+}
+
+func TestRenderDeviceConfigsFunction_InterfaceGroupPolicyMergeDefault(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRenderDeviceConfigs_interfaceGroupPolicyMergeDefault(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("eth1_mtu", "9216"),
+					resource.TestCheckOutput("eth1_shutdown", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRenderDeviceConfigs_interfaceGroupPolicyMergeDefault() string {
+	return `
+	locals {
+		model = {
+			iosxe = {
+				interface_groups = [
+					{
+						name = "base"
+						configuration = {
+							shutdown = true
+						}
+					},
+					{
+						name = "fabric"
+						configuration = {
+							mtu = 9216
+						}
+					}
+				]
+				device_groups = [
+					{
+						name    = "switches"
+						devices = ["switch1"]
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["base"]
+									}
+								]
+							}
+						}
+					}
+				]
+				devices = [
+					{
+						name = "switch1"
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["fabric"]
+									}
+								]
+							}
+						}
+					}
+				]
+			}
+		}
+
+		result = provider::utils::render_device_configs([], local.model, "", {}, [], [])
+		device = local.result.raw.iosxe.devices[0]
+		eth1   = local.device.configuration.interfaces.ethernets[0]
+	}
+
+	output "eth1_mtu" {
+		value = tostring(local.eth1.mtu)
+	}
+	output "eth1_shutdown" {
+		value = tostring(local.eth1.shutdown)
+	}
+	`
+}
+
+func TestRenderDeviceConfigsFunction_InterfaceGroupPolicyPerInterface(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRenderDeviceConfigs_interfaceGroupPolicyPerInterface(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("eth1_mtu", "9216"),
+					resource.TestCheckOutput("eth2_mtu", "1500"),
+					resource.TestCheckOutput("eth2_description", "FROM_ACCESS_GROUP"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRenderDeviceConfigs_interfaceGroupPolicyPerInterface() string {
+	return `
+	locals {
+		model = {
+			iosxe = {
+				interface_groups = [
+					{
+						name = "access"
+						configuration = {
+							mtu = 1500
+							shutdown = true
+							description = "FROM_ACCESS_GROUP"
+						}
+					},
+					{
+						name = "trunk"
+						configuration = {
+							mtu = 9216
+						}
+					},
+					{
+						name = "monitor"
+						configuration = {
+							mtu = 1500
+							shutdown = false
+						}
+					}
+				]
+				device_groups = [
+					{
+						name    = "switches"
+						devices = ["switch1"]
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["access"]
+									},
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/2"
+										interface_groups = ["access"]
+									}
+								]
+							}
+						}
+					}
+				]
+				devices = [
+					{
+						name = "switch1"
+						interface_group_policy = "replace"
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["trunk"]
+									},
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/2"
+										interface_group_policy = "merge"
+										interface_groups = ["monitor"]
+									}
+								]
+							}
+						}
+					}
+				]
+			}
+		}
+
+		result = provider::utils::render_device_configs([], local.model, "", {}, [], [])
+		device = local.result.raw.iosxe.devices[0]
+		eth1   = [for e in local.device.configuration.interfaces.ethernets : e if e.type == "GigabitEthernet" && e.id == "1/0/1"][0]
+		eth2   = [for e in local.device.configuration.interfaces.ethernets : e if e.type == "GigabitEthernet" && e.id == "1/0/2"][0]
+	}
+
+	output "eth1_mtu" {
+		value = tostring(local.eth1.mtu)
+	}
+	output "eth2_mtu" {
+		value = tostring(local.eth2.mtu)
+	}
+	output "eth2_description" {
+		value = local.eth2.description
+	}
+	`
+}
+
+func TestRenderDeviceConfigsFunction_InterfaceGroupPolicyInheritOnly(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRenderDeviceConfigs_interfaceGroupPolicyInheritOnly(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("eth1_mtu", "9216"),
+					resource.TestCheckOutput("eth2_description", "ACCESS_PORT"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRenderDeviceConfigs_interfaceGroupPolicyInheritOnly() string {
+	return `
+	locals {
+		model = {
+			iosxe = {
+				interface_groups = [
+					{
+						name = "access"
+						configuration = {
+							description = "ACCESS_PORT"
+						}
+					},
+					{
+						name = "trunk"
+						configuration = {
+							mtu = 9216
+						}
+					}
+				]
+				device_groups = [
+					{
+						name    = "switches"
+						devices = ["switch1"]
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["access"]
+									},
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/2"
+										interface_groups = ["access"]
+									}
+								]
+							}
+						}
+					}
+				]
+				devices = [
+					{
+						name = "switch1"
+						interface_group_policy = "replace"
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["trunk"]
+									}
+								]
+							}
+						}
+					}
+				]
+			}
+		}
+
+		result = provider::utils::render_device_configs([], local.model, "", {}, [], [])
+		device = local.result.raw.iosxe.devices[0]
+		eth1   = [for e in local.device.configuration.interfaces.ethernets : e if e.type == "GigabitEthernet" && e.id == "1/0/1"][0]
+		eth2   = [for e in local.device.configuration.interfaces.ethernets : e if e.type == "GigabitEthernet" && e.id == "1/0/2"][0]
+	}
+
+	output "eth1_mtu" {
+		value = tostring(local.eth1.mtu)
+	}
+	output "eth2_description" {
+		value = local.eth2.description
+	}
+	`
+}
+
+func TestRenderDeviceConfigsFunction_InterfaceGroupPolicyEmptyList(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRenderDeviceConfigs_interfaceGroupPolicyEmptyList(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("eth1_has_mtu", "false"),
+					resource.TestCheckOutput("eth1_description", "STRIPPED"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRenderDeviceConfigs_interfaceGroupPolicyEmptyList() string {
+	return `
+	locals {
+		model = {
+			iosxe = {
+				interface_groups = [
+					{
+						name = "access"
+						configuration = {
+							mtu = 1500
+							description = "ACCESS_PORT"
+						}
+					}
+				]
+				device_groups = [
+					{
+						name    = "switches"
+						devices = ["switch1"]
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = ["access"]
+									}
+								]
+							}
+						}
+					}
+				]
+				devices = [
+					{
+						name = "switch1"
+						interface_group_policy = "replace"
+						configuration = {
+							interfaces = {
+								ethernets = [
+									{
+										type = "GigabitEthernet"
+										id   = "1/0/1"
+										interface_groups = []
+										description = "STRIPPED"
+									}
+								]
+							}
+						}
+					}
+				]
+			}
+		}
+
+		result = provider::utils::render_device_configs([], local.model, "", {}, [], [])
+		device = local.result.raw.iosxe.devices[0]
+		eth1   = local.device.configuration.interfaces.ethernets[0]
+	}
+
+	output "eth1_has_mtu" {
+		value = tostring(can(local.eth1.mtu))
+	}
+	output "eth1_description" {
+		value = local.eth1.description
+	}
+	`
+}

--- a/internal/provider/function_render_device_configs_test.go
+++ b/internal/provider/function_render_device_configs_test.go
@@ -1786,3 +1786,106 @@ func testAccRenderDeviceConfigs_interfaceGroupPolicyEmptyList() string {
 	}
 	`
 }
+
+func TestRenderDeviceConfigsFunction_InterfaceGroupPolicySubinterface(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRenderDeviceConfigs_interfaceGroupPolicySubinterface(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("sub10_mtu", "9216"),
+					resource.TestCheckOutput("sub20_description", "BASE_VIA_GROUP"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRenderDeviceConfigs_interfaceGroupPolicySubinterface() string {
+	return `
+	locals {
+		model = {
+			iosxe = {
+				interface_groups = [
+					{
+						name = "base_sub"
+						configuration = {
+							description = "BASE_VIA_GROUP"
+							mtu = 1500
+						}
+					},
+					{
+						name = "fabric_sub"
+						configuration = {
+							mtu = 9216
+						}
+					}
+				]
+				device_groups = [
+					{
+						name    = "routers"
+						devices = ["router1"]
+						configuration = {
+							interfaces = {
+								port_channels = [
+									{
+										id = 1
+										subinterfaces = [
+											{
+												id = "10"
+												interface_groups = ["base_sub"]
+											},
+											{
+												id = "20"
+												interface_groups = ["base_sub"]
+											}
+										]
+									}
+								]
+							}
+						}
+					}
+				]
+				devices = [
+					{
+						name = "router1"
+						interface_group_policy = "replace"
+						configuration = {
+							interfaces = {
+								port_channels = [
+									{
+										id = 1
+										subinterfaces = [
+											{
+												id = "10"
+												interface_groups = ["fabric_sub"]
+											}
+										]
+									}
+								]
+							}
+						}
+					}
+				]
+			}
+		}
+
+		result = provider::utils::render_device_configs([], local.model, "", {}, [], [])
+		device = local.result.raw.iosxe.devices[0]
+		pc1    = [for p in local.device.configuration.interfaces.port_channels : p if p.id == 1][0]
+		sub10  = [for s in local.pc1.subinterfaces : s if s.id == "10"][0]
+		sub20  = [for s in local.pc1.subinterfaces : s if s.id == "20"][0]
+	}
+
+	output "sub10_mtu" {
+		value = tostring(local.sub10.mtu)
+	}
+	output "sub20_description" {
+		value = local.sub20.description
+	}
+	`
+}


### PR DESCRIPTION
## Summary

Adds support for an `interface_group_policy` attribute that controls how `interface_groups` are resolved between device_group and device layers in `render_device_configs`.

- `merge` (default): existing behavior preserved. Interface_groups from device_groups and devices are concatenated.
- `replace`: device-level interface_groups completely replace inherited ones. Only groups explicitly listed at the device level are applied.

## Motivation

Customers using interface_groups at the device_group level need the ability to override (not just extend) those groups at the device level for specific interfaces. A common pattern is defining a "free port" interface_group at the device_group layer, then needing to fully replace it with a "trunk port" group for specific interfaces on specific devices.

Previously implemented in the IOS-XE module's HCL ([terraform-iosxe-nac-iosxe#337](https://github.com/netascode/terraform-iosxe-nac-iosxe/pull/337)), but that logic was removed when the module was refactored to use `render_device_configs` ([#315](https://github.com/netascode/terraform-iosxe-nac-iosxe/pull/315)). Implementing here makes the feature available across all NAC platforms (IOS-XE, NX-OS, IOS-XR).

## Design

The policy can be set at two levels:

1. **Device level** (`devices[].interface_group_policy`) - default for all interfaces on the device
2. **Per-interface level** (`ethernets[].interface_group_policy`, etc.) - overrides device-level

Precedence: `per-interface > device-level > "merge"`

Key behaviors:
- Replace only activates for interfaces the device explicitly redefines. Interfaces only defined in a device_group still inherit their groups.
- `interface_groups: []` with replace strips all inherited groups.
- Per-interface `merge` can override device-level `replace`.

## Implementation

A new `applyInterfaceGroupPolicy` function runs after the 9-level merge cascade but before `applyInterfaceGroups`. It uses `itemsWouldMerge` (the same primitive-field matching that `MergeMaps` uses) for platform-agnostic interface identity, so it works with any architecture's naming conventions.

No changes to `MergeMaps` or `applyInterfaceGroups` - the intervention is a clean post-merge fixup.

## Test Evidence

5 new test cases, all passing:

```
=== RUN   TestRenderDeviceConfigsFunction_InterfaceGroupPolicyReplace
--- PASS: TestRenderDeviceConfigsFunction_InterfaceGroupPolicyReplace (0.66s)
=== RUN   TestRenderDeviceConfigsFunction_InterfaceGroupPolicyMergeDefault
--- PASS: TestRenderDeviceConfigsFunction_InterfaceGroupPolicyMergeDefault (0.40s)
=== RUN   TestRenderDeviceConfigsFunction_InterfaceGroupPolicyPerInterface
--- PASS: TestRenderDeviceConfigsFunction_InterfaceGroupPolicyPerInterface (0.40s)
=== RUN   TestRenderDeviceConfigsFunction_InterfaceGroupPolicyInheritOnly
--- PASS: TestRenderDeviceConfigsFunction_InterfaceGroupPolicyInheritOnly (0.41s)
=== RUN   TestRenderDeviceConfigsFunction_InterfaceGroupPolicyEmptyList
--- PASS: TestRenderDeviceConfigsFunction_InterfaceGroupPolicyEmptyList (0.41s)
PASS
```

Full existing test suite (24 tests) passes with no regressions.

### Integration validation

Tested with a realistic IOS-XE data model through `render_device_configs`:

```yaml
iosxe:
  interface_groups:
    - name: IFG_ACCESS_PORT
      configuration:
        description: "ACCESS_PORT_VIA_GROUP"
        switchport:
          mode: access
          access_vlan: 999
        shutdown: true

    - name: IFG_TRUNK_PORT
      configuration:
        description: "TRUNK_PORT_VIA_GROUP"
        switchport:
          mode: trunk
          trunk_allowed_vlans: "100-200"
        shutdown: false

    - name: IFG_MONITOR_PORT
      configuration:
        description: "MONITOR_PORT_VIA_GROUP"
        switchport:
          mode: access
          access_vlan: 500
        shutdown: false

  device_groups:
    - name: DG_TEST_REPLACE
      devices:
        - switch1
      configuration:
        interfaces:
          ethernets:
            - type: GigabitEthernet
              id: "1/0/2"
              interface_groups: [IFG_ACCESS_PORT]
            - type: GigabitEthernet
              id: "1/0/3"
              interface_groups: [IFG_ACCESS_PORT]
            - type: GigabitEthernet
              id: "1/0/5"
              interface_groups: [IFG_ACCESS_PORT]
            - type: GigabitEthernet
              id: "1/0/6"
              interface_groups: [IFG_ACCESS_PORT]
            - type: GigabitEthernet
              id: "1/0/7"
              interface_groups: [IFG_ACCESS_PORT]

  devices:
    - name: switch1
      url: https://192.0.2.60
      interface_group_policy: replace
      configuration:
        interfaces:
          ethernets:
            # Gi1/0/2: replace - only TRUNK (no access vlan 999)
            - type: GigabitEthernet
              id: "1/0/2"
              interface_groups: [IFG_TRUNK_PORT]
            # Gi1/0/5: replace with empty list - strip all groups
            - type: GigabitEthernet
              id: "1/0/5"
              interface_groups: []
              description: "STRIPPED_ALL_GROUPS"
            # Gi1/0/6: per-interface merge overrides device replace
            - type: GigabitEthernet
              id: "1/0/6"
              interface_group_policy: merge
              interface_groups: [IFG_MONITOR_PORT]
            # Gi1/0/7: inherits device-level replace - only TRUNK
            - type: GigabitEthernet
              id: "1/0/7"
              interface_groups: [IFG_TRUNK_PORT]
          # Gi1/0/3: NOT redefined at device level - inherited groups apply
```

**Resolved model output (from `terraform plan`):**

```yaml
iosxe:
  devices:
    - name: switch1
      configuration:
        interfaces:
          ethernets:
            - type: GigabitEthernet
              id: 1/0/2
              description: TRUNK_PORT_VIA_GROUP
              shutdown: false
              switchport:
                mode: trunk
                trunk_allowed_vlans: 100-200
            - type: GigabitEthernet
              id: 1/0/3
              description: ACCESS_PORT_VIA_GROUP
              shutdown: true
              switchport:
                access_vlan: 999
                mode: access
            - type: GigabitEthernet
              id: 1/0/5
              description: STRIPPED_ALL_GROUPS
            - type: GigabitEthernet
              id: 1/0/6
              description: MONITOR_PORT_VIA_GROUP
              shutdown: false
              switchport:
                access_vlan: 500
                mode: access
            - type: GigabitEthernet
              id: 1/0/7
              description: TRUNK_PORT_VIA_GROUP
              shutdown: false
              switchport:
                mode: trunk
                trunk_allowed_vlans: 100-200
```

## Notes

- Fully backward compatible - default is `merge`, no behavior change for existing configurations
- Tested with IOS-XE architecture only. NX-OS and IOS-XR have not been validated, though the implementation uses `itemsWouldMerge` (platform-agnostic primitive-field matching) and should work for any architecture that passes `interface_group_policy` through the data model.
- Companion schema changes for IOS-XE are prepared separately on the enterprise GHE repo
- NX-OS and IOS-XR schemas would need their own `interface_group_policy` attributes added to benefit

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: feature implementation + tests
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart